### PR TITLE
[BUGFIX][FRONTEND] Issue 57: Fix advance search template error

### DIFF
--- a/communitter-frontend/src/components/AdvancedSearch.js
+++ b/communitter-frontend/src/components/AdvancedSearch.js
@@ -59,6 +59,7 @@ const AdvancedSearchModal = ({
           filterObject = { type: "date", start: 0, end: 0 };
           break;
         case "image":
+          filterObject = { type: "image"};
           break;
         case "geolocation":
           filterObject = {


### PR DESCRIPTION
- The problem was, in the handle template change the filteredObject was not created for data type image.
- Therefore, if a template had an image data type, filteredObject would be undefined and activated property could not be found.
-
- filteredObject is added for the case image.


[Issue Link](https://github.com/SWE574-G3/SWE-574-G3/issues/57)