### PR TITLE
[DEV][BUGFIX] Issue 95: Add postvote relation in post model

### DIFF
--- a/Communitter/src/main/java/com/communitter/api/model/Post.java
+++ b/Communitter/src/main/java/com/communitter/api/model/Post.java
@@ -60,4 +60,17 @@ public class Post {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private Set<Comment> comments;
+
+    @OneToMany(
+            mappedBy = "post",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    @Cascade(org.hibernate.annotations.CascadeType.REMOVE)
+    @JsonManagedReference("post-votes")
+    @JsonIgnore
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private Set<PostVote> postVotes;
 }


### PR DESCRIPTION
PostVote relation is added to Post model.
Cascade type is set to delete the votes when deleting the post.
Posts are deleted even they have vote on themselves.