### PR TITLE
Hotfix/126/backend out of memory

### DIFF
--- a/Communitter/src/main/java/com/communitter/api/auth/JwtAuthFilter.java
+++ b/Communitter/src/main/java/com/communitter/api/auth/JwtAuthFilter.java
@@ -47,9 +47,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if(userMail!=null && SecurityContextHolder.getContext().getAuthentication()==null){
             logger.info("Entered userDetails check");
             UserDetails userDetails =(userDetailsService.loadUserByUsername(userMail));
+            boolean isTokenValid = jwtService.isTokenValid(jwt,(User) userDetails);
             logger.info("User Details are: "+userDetails.toString());
-            logger.info("Is Token Valid: "+jwtService.isTokenValid(jwt,(User) userDetails));
-            if(jwtService.isTokenValid(jwt,(User) userDetails)){
+            logger.info("Is Token Valid: "+isTokenValid);
+            if(isTokenValid){
                 UsernamePasswordAuthenticationToken authToken= new UsernamePasswordAuthenticationToken(
                         userDetails,
                         null,

--- a/Communitter/src/main/java/com/communitter/api/model/ActivityStream.java
+++ b/Communitter/src/main/java/com/communitter/api/model/ActivityStream.java
@@ -1,9 +1,8 @@
 package com.communitter.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -24,8 +23,11 @@ public class ActivityStream {
             generator = "activity_stream_sequence")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnoreProperties({"posts","labels","creator","subscriptions"})
     @JoinColumn(name = "community_id", nullable = false)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     private Community community;
 
     @Column(nullable = false)
@@ -35,11 +37,17 @@ public class ActivityStream {
     @Column(nullable = false)
     private ActivityAction action;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @JsonIgnoreProperties({"avatar","about","subscriptions","interests","posts","createdCommunities","accountNonExpired","accountNonLocked","credentialsNonExpired","authorities"})
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = true)
+    @JsonIgnoreProperties({"community","activityStreams","author","comments","postFields","template","postVotes"})
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     private Post post;
 }

--- a/Communitter/src/main/resources/application.properties
+++ b/Communitter/src/main/resources/application.properties
@@ -12,6 +12,6 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 #Use this if you want to run the project in local env
 #spring.profiles.active=local
-#spring.datasource.url=jdbc:postgresql://localhost:5432/communitter
+spring.datasource.url=jdbc:postgresql://localhost:5432/communitter
 
 


### PR DESCRIPTION
- Some refining on Hibernate Models
- Redundant method calls removed from security filter chain workflow

Memory allocations for filter chain dropped by 50%, observed via IntelliJ profiler.
